### PR TITLE
Docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,8 @@
 .gradle
 build
 run
+templates
+images
 
 *.md
 *.json

--- a/.dockerignore
+++ b/.dockerignore
@@ -5,5 +5,7 @@ run
 
 *.md
 *.json
+*.zip
+*.txt
 gradlew.bat
 template.xsd

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.git
+.gradle
+build
+run
+
+*.md
+*.json
+gradlew.bat
+template.xsd

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build
+.gradle

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,7 @@
+.gradle
 build
-gradle
 images
 templates
-.gradle
-
 
 *.swp
 *.txt

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,10 @@
 build
+gradle
+images
+templates
 .gradle
+
+
+*.swp
+*.txt
+*.zip

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM gradle:jdk16 AS compiler
 WORKDIR /home/gradle
 
-COPY build.gradle gradlew settings.gradle ./
+COPY gradle build.gradle gradlew settings.gradle ./
 COPY src src
-RUN gradle -i --no-daemon shadowJar
+RUN gradle --no-daemon shadowJar
 
 FROM adoptopenjdk:16-jre-hotspot AS runner
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM gradle:jdk16 AS compiler
+WORKDIR /home/gradle/project
+COPY build.gradle gradlew settings.gradle ./
+COPY src src
+RUN gradle shadowJar
+
+FROM adoptopenjdk:16-jre-hotspot AS runner
+WORKDIR /app
+COPY --from=compiler /home/gradle/project/build/**/*.jar proximity.jar
+CMD ["java", "-jar", "proximity.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,13 @@
 FROM gradle:jdk16 AS compiler
-WORKDIR /home/gradle/project
+WORKDIR /home/gradle
+
 COPY build.gradle gradlew settings.gradle ./
 COPY src src
-RUN gradle shadowJar
+RUN gradle -i --no-daemon shadowJar
 
 FROM adoptopenjdk:16-jre-hotspot AS runner
 WORKDIR /app
-COPY --from=compiler /home/gradle/project/build/**/*.jar proximity.jar
-CMD ["java", "-jar", "proximity.jar"]
+COPY --from=compiler /home/gradle/build/**/*.jar proximity.jar
+
+CMD ["--cards=cards.txt", "--template=template.zip"]
+ENTRYPOINT ["java", "-jar", "proximity.jar"]

--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
 # Proximity
 A tool to assemble Magic: The Gathering proxies from a set of template images
+
+# Docker support
+To run this tool in docker, clone the repository, then run: 
+```
+docker build proximity:latest .
+```
+
+Once it's done building, run the following:
+```
+docker run -v $PWD/_CARDS_:/app/cards.txt -v $PWD/_TEMPLATE_.zip:/app/templates/template.zip -v $(PWD)/images:/app/images proximity:latest
+```
+
+Where `_CARDS_` is the name of the file containing your cards list, and `_TEMPLATE_` is the name of your template zip file.
+Output of proximity will end up in a folder named `images`.


### PR DESCRIPTION
Some pretty bare bones docker support, but for someone like me who likes running stuff via docker from the CLI, this works. We could probably improve it a lot in the future, by (somehow) caching the gradle dependencies in a separate step, and maybe providing a docker-compose file for easier volume mounting. But this is at least a start.